### PR TITLE
Link, copy, and contact fixes

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -392,6 +392,18 @@ main {
   color: var(--orange);
 }
 
+/* Links inside the hero sit on a dark ground in both themes, so they cannot
+   use the page accent colour. */
+.hero__lede a {
+  color: #fff;
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 255, 255, 0.5);
+  text-underline-offset: 3px;
+}
+.hero__lede a:hover {
+  text-decoration-color: var(--orange);
+}
+
 .hero__art {
   display: grid;
   place-items: center;

--- a/data/links.json
+++ b/data/links.json
@@ -29,7 +29,7 @@
     },
     {
       "text": "Linux",
-      "link": "https://github.com/RavenProject/Ravencoin/releases/download/v4.3.2.1/raven-4.3.2.1-x86_64-linux-gnu.tar.gz"
+      "link": "https://github.com/RavenProject/Ravencoin/releases"
     },
     {
       "text": "iOS",

--- a/data/people.json
+++ b/data/people.json
@@ -48,6 +48,7 @@
       "strengths": ["Ravencoin Core", "C++", "Protocol design", "Assets"],
       "bio": "Long-time Ravencoin developer and the contact point for development proposals and bounties.",
       "links": {
+        "x": "https://x.com/tronblack",
         "email": "tron@ravencoin.foundation",
         "medium": "https://medium.com/@tronblack"
       }

--- a/index.html
+++ b/index.html
@@ -43,9 +43,11 @@
             <span class="eyebrow">Non-profit · Supporting open source</span>
             <h1>Helping Ravencoin soar.</h1>
             <p class="hero__lede">
-              Ravencoin is not a company. It is technology, source code, and the network that
-              emerges when people run it. The Foundation exists to support that project — and to
-              keep every Ravencoin resource on the web easy to find.
+              The Ravencoin Foundation is not Ravencoin. Ravencoin is
+              <a href="https://github.com/RavenProject/Ravencoin" target="_blank" rel="noopener noreferrer">open-source software</a>
+              that volunteers run to create a network of nodes that constructs a massively
+              replicated blockchain-based ledger for RVN, and for any other asset tokens that get
+              created by the network users.
             </p>
             <div class="hero__actions">
               <a class="btn btn--primary" href="#resources">
@@ -122,13 +124,6 @@
             <h2>About the Foundation</h2>
           </div>
           <div class="prose" style="max-width: 74ch">
-            <p>
-              The Ravencoin Foundation is not Ravencoin. Ravencoin is
-              <a href="https://github.com/RavenProject/Ravencoin" target="_blank" rel="noopener noreferrer">open-source software</a>
-              that volunteers run to create a network of nodes, which in turn constructs a massively
-              replicated blockchain-based ledger for RVN and for any other asset tokens created by
-              the network's users.
-            </p>
             <p>
               The Ravencoin Foundation is a non-profit organization that endeavors to assist and
               protect the Ravencoin open-source project. It also provides a legal entity that can


### PR DESCRIPTION
Follow-ups to #14, which was already merged before these landed.

- **Linux download points at the releases page.** The pinned `v4.3.2.1` tarball URL goes stale with every release; `https://github.com/RavenProject/Ravencoin/releases` always lists the current build. Windows and Mac still point at their pinned installers.
- **Home page description restored to the previous site's wording.** #14 shipped a rewrite of the "The Ravencoin Foundation is not Ravencoin…" paragraph; this puts the original text back verbatim in the hero. The same paragraph is dropped from the About section, where it would otherwise repeat within a screen — that section keeps the non-profit paragraph, which was already verbatim.
- **Tron Black's X account added** to `data/people.json`, so the contact card now shows X, Email, and Medium.

One CSS change comes along with the copy fix: links inside the hero are now white with an underline. They were inheriting the page accent colour, which is navy in light theme and unreadable against the dark hero background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)