### PR TITLE
Remove the NFTs section and its links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Edit [`data/links.json`](data/links.json). Each category is a key with an array 
   to give it an icon and a one-line description. Categories display in the order they appear in
   the file, starting with `Download`.
 - Available icon names: `download`, `wallet`, `assets`, `people`, `buy`, `trade`, `swap`, `mining`,
-  `globe`, `nft`, `book`, `code`, `search`, `megaphone`, `doc`, `shield`, `mail`, `ship`.
+  `globe`, `book`, `code`, `search`, `megaphone`, `doc`, `shield`, `mail`, `ship`.
 
 ### Find and mark dead links
 

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -105,7 +105,6 @@
     mining: '<path d="M4 20l8-8M9 7l8 8M6.5 4.5l3 3M17 15l3 3"/><rect x="12" y="3" width="8" height="8" rx="2"/>',
     globe:
       '<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c2.6 3 2.6 15 0 18M12 3c-2.6 3-2.6 15 0 18"/>',
-    nft: '<rect x="3" y="4" width="18" height="16" rx="3"/><circle cx="8.5" cy="9.5" r="1.6"/><path d="M4 17l5-4.5 4 3.5 3-2.5 4 3.5"/>',
     book: '<path d="M4 4.5A2.5 2.5 0 016.5 2H20v16H6.5A2.5 2.5 0 004 20.5z"/><path d="M4 20.5A2.5 2.5 0 016.5 18H20v4H6.5A2.5 2.5 0 014 19.5z"/>',
     code: '<path d="M9 17l-5-5 5-5M15 7l5 5-5 5"/>',
     megaphone: '<path d="M4 10v4a1 1 0 001 1h2l7 4V5L7 9H5a1 1 0 00-1 1z"/><path d="M17.5 8.5a5 5 0 010 7"/>',

--- a/data/links.json
+++ b/data/links.json
@@ -10,7 +10,6 @@
     "Swap": {"icon": "swap", "blurb": "Instant swap services."},
     "Mining Pools": {"icon": "mining", "blurb": "Pools for mining RVN with KAWPOW."},
     "Sites": {"icon": "globe", "blurb": "Community sites and portals."},
-    "NFTs": {"icon": "nft", "blurb": "Marketplaces and galleries for Ravencoin NFTs."},
     "Learn": {"icon": "book", "blurb": "Docs, research, news, and stats."},
     "Developers": {"icon": "code", "blurb": "Source, tooling, and APIs."},
     "Explorers": {"icon": "search", "blurb": "Block, asset, and testnet explorers."},
@@ -120,17 +119,6 @@
     {"text": "Whats Up RVN", "link": "https://whatsuprvn.com", "status": "unreachable"},
     {"text": "Why Ravencoin?", "link": "https://whyravencoin.com"},
     {"text": "Charts", "link": "http://charts.ravencoin.timeline.ovh", "status": "unreachable"}
-  ],
-  "NFTs": [
-    {"text": "NFTRVN", "link": "https://nftrvn.net/", "status": "unreachable"},
-    {"text": "Just NFTs", "link": "https://marketplace.justnfts.io/", "status": "unreachable"},
-    {"text": "RVNFT Art", "link": "https://www.rvnft.art/", "status": "unreachable"},
-    {"text": "Nifty Synth", "link": "https://niftysynth.com/"},
-    {"text": "Raven Trader", "link": "https://raventrader.net/", "status": "unreachable"},
-    {"text": "Asset Market", "link": "https://theassetmarketplace.com/", "status": "unreachable"},
-    {"text": "Ravenist", "link": "https://www.ravenist.com/"},
-    {"text": "WAGMI NFT", "link": "https://wagminft.net/", "status": "unreachable"},
-    {"text": "Mellori Market", "link": "https://mellori.market/", "status": "unreachable"}
   ],
   "Learn": [
     {"text": "Whitepaper", "link": "https://ravencoin.org/assets/documents/Ravencoin.pdf"},

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             <span class="eyebrow">The directory</span>
             <h2>Every Ravencoin resource</h2>
             <p>
-              Wallets, exchanges, explorers, mining pools, NFT marketplaces, developer tools, and
+              Wallets, exchanges, explorers, mining pools, developer tools, and
               community sites — maintained by the Foundation so you always have a starting point.
               Search, or filter by category.
             </p>

--- a/links/index.html
+++ b/links/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Resources | Ravencoin Foundation</title>
-    <meta name="description" content="Every Ravencoin wallet, exchange, explorer, mining pool, NFT marketplace, developer tool and community site, in one searchable directory." />
+    <meta name="description" content="Every Ravencoin wallet, exchange, explorer, mining pool, developer tool and community site, in one searchable directory." />
     <link rel="canonical" href="https://ravencoin.foundation/links/" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" href="/assets/img/raven-bird.svg" type="image/svg+xml" />
@@ -12,7 +12,7 @@
     <meta name="theme-color" content="#1b2050" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Resources | Ravencoin Foundation" />
-    <meta property="og:description" content="Every Ravencoin wallet, exchange, explorer, mining pool, NFT marketplace, developer tool and community site, in one searchable directory." />
+    <meta property="og:description" content="Every Ravencoin wallet, exchange, explorer, mining pool, developer tool and community site, in one searchable directory." />
     <meta property="og:image" content="https://ravencoin.foundation/assets/img/raven-512.png" />
     <link rel="stylesheet" href="/assets/css/site.css" />
     <script>


### PR DESCRIPTION
Drops the `NFTs` category and all nine of its links, leaving 13 categories and 117 links.

Removed: NFTRVN, Just NFTs, RVNFT Art, Nifty Synth, Raven Trader, Asset Market, Ravenist, WAGMI NFT, Mellori Market.

Seven of the nine were already flagged unreachable by #16. **Nifty Synth and Ravenist were live** — they are the only working resources this drops.

## Cleanup that came with it

The section left references behind, so this also removes:

- the `nft` icon in `site.js`, now unused, and its entry in the README's icon list
- "NFT marketplaces" from the home page directory blurb
- "NFT marketplace" from the `/links/` meta description and og:description

## Deliberately left alone

- **`Participate` → RVNFT Art** (`rvnft.art`). A separate entry in a different category, not part of the removed section. Currently dimmed for an expired TLS certificate.
- **"Wallets that can hold Ravencoin assets and NFTs"** — the `Asset Wallets` blurb and the matching card on `/downloads/`. That describes what those wallets do, and stays accurate with the section gone.

Say the word if either should go too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)