### PR TITLE
Point AtomicDEX at atomicdex.com and mark it working

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -59,7 +59,7 @@
   ],
   "Trade": [
     {"text": "ATAIX", "link": "https://ataix.com/market/RVN-BTC"},
-    {"text": "AtomicDEX", "link": "https://www.atomicexplorer.com/#/coins", "status": "unreachable"},
+    {"text": "AtomicDEX", "link": "https://www.atomicdex.com/"},
     {"text": "BitLadon", "link": "https://www.bitladon.com/ravencoin"},
     {"text": "Bittrue", "link": "https://www.bitrue.com/trade/rvn_btc"},
     {"text": "Binance", "link": "https://www.binance.com/en/trade/RVN_BTC"},


### PR DESCRIPTION
The AtomicDEX entry under `Trade` pointed at `www.atomicexplorer.com/#/coins`, whose DNS no longer resolves — which is why #16 flagged it unreachable.

`https://www.atomicdex.com/` returns 200 and renders the real AtomicDEX Wallet site (verified in a browser, not just by status code — it is a JS SPA, so curl alone only sees a 748-byte shell). The `"status": "unreachable"` flag is dropped along with the URL change, so the link renders at full opacity again.

Dimmed links drop from 30 to 29.

Note: `www.atomicdex.com` redirects to the apex `atomicdex.com`. Kept as given, since the redirect resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)