### PR TITLE
Drop "group" from the meetup booking line

### DIFF
--- a/meetup/index.html
+++ b/meetup/index.html
@@ -70,7 +70,7 @@
             <p>
               Book directly with
               <a href="https://www.royalcaribbean.com/itinerary/8-night-southern-caribbean-perfect-day-from-fort-lauderdale-on-legend-LE08D147?sailDate=2026-11-14&amp;packageCode=LE08D147&amp;groupId=LE08FLL-3549270341&amp;country=USA" target="_blank" rel="noopener noreferrer">Royal Caribbean</a>
-              using the group link above so the community ends up on the same sailing.
+              using the link above so the community ends up on the same sailing.
             </p>
             <p>
               These ships have


### PR DESCRIPTION
On `/meetup/`, "using the group link above" becomes "using the link above".

The booking URL itself is unchanged — it still carries the `groupId` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)