### PR TITLE
Add KawTrace to the Explorers list

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -151,7 +151,8 @@
     {"text": "Blockbook Explorer", "link": "https://blockbook.ravencoin.org/"},
     {"text": "Explorer (MangoFarm)", "link": "https://explorer.mangofarmassets.com/"},
     {"text": "Asset Explorer", "link": "https://ravencoin.asset-explorer.net/"},
-    {"text": "Asset Explorer - 2", "link": "https://www.assetsexplorer.com/"}
+    {"text": "Asset Explorer - 2", "link": "https://www.assetsexplorer.com/"},
+    {"text": "KawTrace", "link": "https://cerberuscx.github.io/KawTrace/#/view/dashboard"}
   ],
   "Awareness": [
     {"text": "Marketing Kit", "link": "https://github.com/underdarkskies/Ravencoin-Marketing"},


### PR DESCRIPTION
Adds **KawTrace** — `https://cerberuscx.github.io/KawTrace/#/view/dashboard` — to the `Explorers` category, bringing it to 9 entries.

Verified in a browser rather than by status code, since it is a hash-routed SPA and a `200` on the shell would prove nothing. It loads, reports "Connected", and shows live mainnet data: block height 4,498,406, difficulty, network hashrate, mempool, and recent blocks and transactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)