### PR TITLE
Make directory searches linkable via the query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ Edit [`data/links.json`](data/links.json). Each category is a key with an array 
 - Available icon names: `download`, `wallet`, `assets`, `people`, `buy`, `trade`, `swap`, `mining`,
   `globe`, `book`, `code`, `search`, `megaphone`, `doc`, `shield`, `mail`, `ship`.
 
+### Link straight to a resource
+
+The directory reads the query string, so any search is a URL you can share or bookmark:
+
+```
+https://ravencoin.foundation/links/?search=KawTrace
+https://ravencoin.foundation/links/?category=Explorers
+https://ravencoin.foundation/links/?category=Mining%20Pools&search=nano
+```
+
+`search` prefills the box and filters; the match is highlighted. `category` preselects a filter
+chip and is forgiving about case and punctuation, so `mining-pools`, `Mining Pools`, and
+`miningpools` all work. `q` and `cat` are accepted as short forms.
+
+It works on any page showing the directory, including `/?search=…` on the home page, which scrolls
+down to the results. The address bar also updates as you type, so a search you did by hand can just
+be copied out of the URL bar.
+
 ### Find and mark dead links
 
 ```bash

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -318,6 +318,8 @@
                   return (
                     '<li data-text="' +
                     esc(l.text.toLowerCase()) +
+                    '" data-label="' +
+                    esc(l.text) +
                     '"><a class="' +
                     (down ? "is-unreachable" : "") +
                     '" href="' +
@@ -365,6 +367,21 @@
         }
 
         var activeCat = "";
+
+        // Wrap the matched part of a label in <mark> so the hit is obvious,
+        // which matters most when a ?search= link drops you straight onto it.
+        function highlight(label, q) {
+          var at = q ? label.toLowerCase().indexOf(q) : -1;
+          if (at === -1) return esc(label);
+          return (
+            esc(label.slice(0, at)) +
+            "<mark>" +
+            esc(label.slice(at, at + q.length)) +
+            "</mark>" +
+            esc(label.slice(at + q.length))
+          );
+        }
+
         function apply() {
           var q = (searchBox ? searchBox.value : "").trim().toLowerCase();
           var anyVisible = false;
@@ -378,7 +395,11 @@
                   li.getAttribute("data-text").indexOf(q) !== -1 ||
                   sec.getAttribute("data-cat").toLowerCase().indexOf(q) !== -1);
               li.classList.toggle("is-hidden", !hit);
-              if (hit) shown++;
+              if (hit) {
+                shown++;
+                var label = el("a span", li);
+                if (label) label.innerHTML = highlight(li.getAttribute("data-label"), q);
+              }
             });
             sec.classList.toggle("is-hidden", shown === 0);
             if (shown) anyVisible = true;
@@ -387,8 +408,50 @@
           if (empty) empty.classList.toggle("is-hidden", anyVisible);
         }
 
+        /* --- Shareable URLs -------------------------------------------------
+           /links/?search=KawTrace lands on that entry; ?category=Explorers
+           preselects a filter. The address bar tracks whatever you type, so a
+           search you did by hand can just be copied out of the URL bar. */
+        function loose(s) {
+          return String(s).toLowerCase().replace(/[^a-z0-9]/g, "");
+        }
+
+        function syncUrl() {
+          if (!window.history || !history.replaceState) return;
+          var p = new URLSearchParams(location.search);
+          var q = searchBox ? searchBox.value.trim() : "";
+          if (q) p.set("search", q);
+          else p.delete("search");
+          if (activeCat) p.set("category", activeCat);
+          else p.delete("category");
+          var qs = p.toString();
+          history.replaceState(null, "", location.pathname + (qs ? "?" + qs : "") + location.hash);
+        }
+
+        function readUrl() {
+          var p = new URLSearchParams(location.search);
+          var q = p.get("search") || p.get("q") || "";
+          var cat = p.get("category") || p.get("cat") || "";
+          if (q && searchBox) searchBox.value = q;
+          if (cat) {
+            var match = categories.filter(function (c) {
+              return loose(c) === loose(cat);
+            })[0];
+            if (match) {
+              activeCat = match;
+              els(".chip", chipBox).forEach(function (c) {
+                c.classList.toggle("is-active", c.getAttribute("data-filter") === match);
+              });
+            }
+          }
+          return !!(q || cat);
+        }
+
         if (searchBox) {
-          searchBox.addEventListener("input", apply);
+          searchBox.addEventListener("input", function () {
+            apply();
+            syncUrl();
+          });
           searchBox.removeAttribute("disabled");
         }
         if (chipBox) {
@@ -400,6 +463,21 @@
               c.classList.toggle("is-active", c === chip);
             });
             apply();
+            syncUrl();
+          });
+        }
+
+        if (readUrl()) {
+          apply();
+          // On pages where the directory sits below a hero, bring it into view
+          // so the deep link actually shows the thing it filtered to. Jump
+          // rather than smooth-scroll: the page is still settling here, and an
+          // animated scroll gets interrupted by the layout shifting under it.
+          requestAnimationFrame(function () {
+            var target = el("#link-search") || container;
+            if (target.getBoundingClientRect().top > window.innerHeight * 0.5) {
+              target.scrollIntoView({ block: "center", behavior: "auto" });
+            }
           });
         }
 


### PR DESCRIPTION
Any search in the resource directory is now a URL you can share or bookmark:

```
/links/?search=KawTrace
/links/?category=Explorers
/links/?category=Mining%20Pools&search=nano
```

- **`search`** prefills the box, filters the list, and highlights the match.
- **`category`** preselects a filter chip, matched loosely — `mining-pools`, `Mining Pools`, and `miningpools` all resolve to the same category.
- `q` and `cat` are accepted as short forms, and the two parameters combine.
- The address bar updates as you type, so a search done by hand can be copied straight out of the URL bar.

Works anywhere the directory renders, including `/?search=…` on the home page.

**Search-term highlighting is new in general**, not just for deep links. The `.linkcat li a mark` CSS was already in the stylesheet from the original build, but nothing ever rendered a `<mark>` — this wires it up, which is what makes a `?search=` link visibly land on its target.

## Verified

On `/links/?search=KawTrace`: box prefilled, only the Explorers card shown, only KawTrace inside it, match highlighted, URL preserved. `?category=mining-pools` activates the Mining Pools chip; typing `nano` afterwards updates the URL to `?category=Mining+Pools&search=nano` and narrows to NanoPool. Filtering also confirmed on the home page.

**Not verified:** the scroll-into-view for `/?search=…` on the home page. Programmatic scrolling is a no-op in my preview environment — even a plain `window.scrollTo` does nothing on a 3122px document — so I could not exercise that path. The guard around it is confirmed correct in both directions (on `/links/` the search box sits at 317px against a 430px threshold, so it does not fire; on the home page it does), and the worst case if the scroll misbehaves is that the page simply does not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)