### PR TITLE
Give the link panels a uniform height with scrolling lists

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -662,7 +662,13 @@ a.card:hover {
   display: grid;
   gap: 18px;
   grid-template-columns: repeat(auto-fill, minmax(258px, 1fr));
-  align-items: start;
+  /* Panels sitting side by side share a height, so the grid reads as a grid.
+     One link row is its line box plus its padding; ten of those plus the
+     list's own padding is the cap. See the stacked override further down. */
+  align-items: stretch;
+  --link-rows: 10;
+  --link-row: calc(1.65 * 0.94rem + 16px);
+  --link-list-max: calc(var(--link-rows) * var(--link-row) + 16px);
 }
 
 .linkcat {
@@ -703,11 +709,56 @@ a.card:hover {
   padding: 10px 18px 0;
   font-size: 0.82rem;
   color: var(--muted);
+  /* Reserve two lines so every list starts on the same line across the row. */
+  min-height: calc(2 * 1.65 * 0.82rem + 10px);
 }
 .linkcat ul {
   list-style: none;
   margin: 0;
   padding: 8px;
+  max-height: var(--link-list-max);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+.linkcat ul::-webkit-scrollbar {
+  width: 9px;
+}
+.linkcat ul::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border: 3px solid transparent;
+  background-clip: content-box;
+  border-radius: 999px;
+}
+.linkcat ul::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.links-grid:not(.is-filtered) .linkcat ul {
+  height: var(--link-list-max);
+}
+
+/* Overlay scrollbars stay hidden until you touch them, so a capped list needs
+   its own hint that more is below. These gradients are painted in the list's
+   own scroll space (background-attachment: local), which makes them fade in
+   and out on their own at each end — no script, no state to keep. */
+.linkcat ul {
+  background:
+    linear-gradient(var(--surface) 40%, rgba(255, 255, 255, 0)) top / 100% 22px no-repeat local,
+    linear-gradient(rgba(255, 255, 255, 0), var(--surface) 60%) bottom / 100% 22px no-repeat local,
+    radial-gradient(farthest-side at 50% 0, rgba(22, 24, 58, 0.13), rgba(22, 24, 58, 0)) top / 100% 9px
+      no-repeat scroll,
+    radial-gradient(farthest-side at 50% 100%, rgba(22, 24, 58, 0.13), rgba(22, 24, 58, 0)) bottom / 100% 9px
+      no-repeat scroll;
+}
+:root[data-theme="dark"] .linkcat ul {
+  background:
+    linear-gradient(var(--surface) 40%, rgba(23, 26, 53, 0)) top / 100% 22px no-repeat local,
+    linear-gradient(rgba(23, 26, 53, 0), var(--surface) 60%) bottom / 100% 22px no-repeat local,
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0)) top / 100% 9px no-repeat scroll,
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0)) bottom / 100% 9px
+      no-repeat scroll;
 }
 .linkcat li a {
   display: flex;
@@ -769,11 +820,34 @@ a.card:hover {
   padding: 0 1px;
 }
 
+/* Single column — nothing is side by side, so there is no height to match.
+   Show every link and take the scrollbars away. Below this width the grid is
+   forced to one column so the two rules can never disagree. */
+@media (max-width: 620px) {
+  .links-grid {
+    grid-template-columns: 1fr;
+  }
+  .linkcat ul,
+  .links-grid:not(.is-filtered) .linkcat ul {
+    height: auto;
+    max-height: none;
+    overflow-y: visible;
+  }
+  .linkcat ul,
+  :root[data-theme="dark"] .linkcat ul {
+    background: none;
+  }
+  .linkcat__blurb {
+    min-height: 0;
+  }
+}
+
 .is-hidden {
   display: none !important;
 }
 
 .empty-state {
+  grid-column: 1 / -1;
   text-align: center;
   color: var(--muted);
   padding: 40px 0;

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -406,6 +406,9 @@
           });
           var empty = el("#link-empty");
           if (empty) empty.classList.toggle("is-hidden", anyVisible);
+          // Panels are pinned to a uniform ten rows only while the full list is
+          // showing; once filtered they shrink to whatever matched.
+          container.classList.toggle("is-filtered", !!q || !!activeCat);
         }
 
         /* --- Shareable URLs -------------------------------------------------


### PR DESCRIPTION
Side by side, panels were as tall as their contents, so a row could put a 21-link panel next to a 2-link one. Every list is now pinned to ten rows and scrolls past that, so every panel is the same height.

## Desktop

- **Every panel is exactly 541px** — verified across all 14 categories on `/links/`, the home page, and `/downloads/`: one distinct height, not one per row.
- **Ten links tall.** The list box caps at 424px, which is exactly `10 × 40.81px` rows plus the list's own 16px padding.
- **Lists longer than ten scroll:** RVN Wallets (12), Trade (21), Swap (12), Sites (12). Mining Pools (10) and Developers (10) do *not* — ten fits.
- Trade scrolls from 424px of visible space through 873px of content, reaching its last entry.

## Stacked

Below **620px** the grid is forced to one column. Nothing is beside anything, so the caps and the scroll shadow come off and every link shows — confirmed at 390px: one column, 14 distinct row positions, zero scrolling lists, `overflow-y: visible`, `max-height: none`, and Trade rendering all 21 links.

The forced single column matters: `auto-fill` and the media query can never disagree about whether panels are side by side. Checked the boundary — 620px gives one stacked column with no scrolling, 621px gives two columns with matched heights and scrolling where needed.

## Three details it needed

1. **The blurb reserves two lines.** Some blurbs wrap, some don't; without this the lists start on different lines across a row.
2. **Filtering releases the pinned height.** A search matching two links should not draw a panel with eight empty rows, so `apply()` marks the grid `is-filtered` and panels size to what matched — a KawTrace search gives a 174px panel, and clearing it returns everything to 541px.
3. **A scroll shadow, because the scrollbar is not enough.** macOS overlay scrollbars stay hidden until touched, so a capped list would give no sign there is more below. The shadow is painted in the list's own scroll space (`background-attachment: local`), so it fades in and out at each end by itself — no script, no state. Dark theme gets its own values.

## Also

`.empty-state` now spans the grid instead of sitting in one cell, so "No resources match that search" centres properly.

The `.linkcheck-note` is unaffected by the sizing — confirmed at 45px, not stretched — which is why the height sits on the panel rather than on `grid-auto-rows`.

## Trade-off

Short categories now carry blank space at the bottom: Fundraise has 2 links in a ten-row panel. That is the cost of a uniform grid, and it is what "evenly sized, about ten links tall" asks for. If you would rather panels only match within each row and shrink when a row has nothing tall in it, that is a one-line change — drop the `height` on `.links-grid:not(.is-filtered) .linkcat ul` and the `stretch` alignment does it.

Verified in both themes, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)