### PR TITLE
Add Node Monitor to Developers

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -146,7 +146,8 @@
     {"text": "Asset Anatomy", "link": "https://hans-schmidt.github.io/mastering_ravencoin/analysis/Anatomy_of_a_Ravencoin_Asset_Transaction_Script.html"},
     {"text": "Foundation GitHub", "link": "https://github.com/RavencoinFoundation"},
     {"text": "wxRaven (IRE/IDE)", "link": "https://wxraven.link", "status": "unreachable"},
-    {"text": "DevKit", "link": "https://github.com/RavenDevKit"}
+    {"text": "DevKit", "link": "https://github.com/RavenDevKit"},
+    {"text": "Node Monitor", "link": "https://ravencoin-node-monitor.vercel.app/"}
   ],
   "Explorers": [
     {"text": "Block Explorer", "link": "https://api.ravencoin.org/", "status": "unreachable"},


### PR DESCRIPTION
Adds **Node Monitor** — `https://ravencoin-node-monitor.vercel.app/` — to the `Developers` category, appended after DevKit.

Checked live before adding: returns 200 and serves a real page titled *"Ravencoin Node Monitor — Public Demo"*, so it goes in with no `status` flag and renders at full opacity.

## One side effect worth noting

This is Developers' **eleventh** link, which pushes it one row past the ten-row cap introduced in #24. The panel now scrolls — verified it scrolls 41px, exactly one row, to bring Node Monitor into view as the last item. Panels all remain 541px.

Categories now scrolling: RVN Wallets, Trade, Swap, Sites, and Developers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)